### PR TITLE
Correct documentation regarding fontSizes mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ export default {
     primary: 'tomato',
   },
   spacing: [10, 12, 14],
-  fontSize: [16, 20, 24],
+  fontSizes: [16, 20, 24],
   text: {
     h1: {
       fontSize: 3, // this is 24px, taken from `fontSize` above


### PR DESCRIPTION
### What

I believe that the theme `fontSize` mapping should be `fontSizes` as seen here in the code: https://github.com/nandorojo/dripsy/blob/af1f67ad68c85304817458fcd2ab9c60e3c8fe51/src/css/index.tsx#L197