### PR TITLE
Add variants key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.11",
+  "version": "1.1.0-multiple-variants.12",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.6",
+  "version": "1.1.0-multiple-variants.7",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.8",
+  "version": "1.1.0-multiple-variants.9",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.10",
+  "version": "1.1.0-multiple-variants.11",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.3",
+  "version": "1.1.0-multiple-variants.4",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.0.6",
+  "version": "1.1.0-multiple-variants.1",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.1",
+  "version": "1.1.0-multiple-variants.2",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.5",
+  "version": "1.1.0-multiple-variants.6",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.9",
+  "version": "1.1.0-multiple-variants.10",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.12",
+  "version": "1.1.0-multiple-variants.13",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.13",
+  "version": "1.1.0",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.4",
+  "version": "1.1.0-multiple-variants.5",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.2",
+  "version": "1.1.0-multiple-variants.3",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.1.0-multiple-variants.7",
+  "version": "1.1.0-multiple-variants.8",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/src/css/create-themed-component.tsx
+++ b/src/css/create-themed-component.tsx
@@ -21,7 +21,7 @@ export function createThemedComponent<P, T>(
       sx,
       as: SuperComponent,
       variant,
-      style: nativeStyle,
+      style,
       webContainerSx,
       themeKey = options.themeKey,
       variants = options.defaultVariants,
@@ -46,7 +46,7 @@ export function createThemedComponent<P, T>(
             breakpoint: Platform.OS === 'web' && ssr ? undefined : breakpoint,
             variant,
             sx,
-            // style,
+            style,
             variants,
           },
           {
@@ -59,7 +59,7 @@ export function createThemedComponent<P, T>(
         breakpoint,
         defaultStyle,
         ssr,
-        // style,
+        style,
         sx,
         theme,
         themeKey,
@@ -78,7 +78,6 @@ export function createThemedComponent<P, T>(
           responsiveStyles={responsiveSSRStyles}
           style={styles}
           ref={ref}
-          nativeStyle={nativeStyle}
           containerStyles={
             webContainerSx as ComponentProps<
               typeof SSRComponent
@@ -89,11 +88,7 @@ export function createThemedComponent<P, T>(
     }
 
     return (
-      <TheComponent
-        {...((props as unknown) as P)}
-        ref={ref}
-        style={[nativeStyle, styles]}
-      />
+      <TheComponent {...((props as unknown) as P)} ref={ref} style={[styles]} />
     )
   })
 

--- a/src/css/create-themed-component.tsx
+++ b/src/css/create-themed-component.tsx
@@ -21,7 +21,7 @@ export function createThemedComponent<P, T>(
       sx,
       as: SuperComponent,
       variant,
-      style,
+      style: nativeStyle,
       webContainerSx,
       themeKey = options.themeKey,
       variants = options.defaultVariants,
@@ -46,7 +46,7 @@ export function createThemedComponent<P, T>(
             breakpoint: Platform.OS === 'web' && ssr ? undefined : breakpoint,
             variant,
             sx,
-            style,
+            // style,
             variants,
           },
           {
@@ -59,7 +59,7 @@ export function createThemedComponent<P, T>(
         breakpoint,
         defaultStyle,
         ssr,
-        style,
+        // style,
         sx,
         theme,
         themeKey,
@@ -78,6 +78,7 @@ export function createThemedComponent<P, T>(
           responsiveStyles={responsiveSSRStyles}
           style={styles}
           ref={ref}
+          nativeStyle={nativeStyle}
           containerStyles={
             webContainerSx as ComponentProps<
               typeof SSRComponent
@@ -88,7 +89,11 @@ export function createThemedComponent<P, T>(
     }
 
     return (
-      <TheComponent {...((props as unknown) as P)} ref={ref} style={styles} />
+      <TheComponent
+        {...((props as unknown) as P)}
+        ref={ref}
+        style={[nativeStyle, styles]}
+      />
     )
   })
 

--- a/src/css/create-themed-component.tsx
+++ b/src/css/create-themed-component.tsx
@@ -24,6 +24,7 @@ export function createThemedComponent<P, T>(
       style,
       webContainerSx,
       themeKey = options.themeKey,
+      variants = options.defaultVariants,
       ...props
     } = prop
     const defaultStyle =
@@ -46,6 +47,7 @@ export function createThemedComponent<P, T>(
             variant,
             sx,
             style,
+            variants,
           },
           {
             ...options,
@@ -53,7 +55,17 @@ export function createThemedComponent<P, T>(
             defaultStyle,
           }
         )(),
-      [breakpoint, defaultStyle, ssr, style, sx, theme, themeKey, variant]
+      [
+        breakpoint,
+        defaultStyle,
+        ssr,
+        style,
+        sx,
+        theme,
+        themeKey,
+        variant,
+        variants,
+      ]
     )
 
     const TheComponent = SuperComponent || Component

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@theme-ui/css'
 import { ThemeProvider, SxProps, useThemeUI } from '@theme-ui/core'
 import { useEffect, useRef, useState } from 'react'
-import { Dimensions, Platform, ScaledSize } from 'react-native'
+import { Dimensions, Platform, StyleSheet, ScaledSize } from 'react-native'
 // import { useDimensions } from '@react-native-community/hooks'
 import { ThemedOptions, StyledProps } from './types'
 import { defaultBreakpoints } from './breakpoints'
@@ -44,14 +44,6 @@ const responsive = (
     if (!Array.isArray(value)) {
       // @ts-ignore
       next[key] = value
-      continue
-    }
-    // for single value arrays, just add it to the style
-    // example: flex: [1]
-    // we do this since we create more dom nodes otherwise
-    if (value.length === 1) {
-      // @ts-ignore
-      next[key] = value[0]
       continue
     }
 
@@ -496,7 +488,7 @@ export function mapPropsToStyledComponent<P, T>(
     sx,
     theme,
     variant = defaultVariant,
-    // style,
+    style,
     variants,
   } = props
 
@@ -529,10 +521,12 @@ export function mapPropsToStyledComponent<P, T>(
       {}
     )
 
-  // const nativeStyles = css(
-  //   Array.isArray(style) ? StyleSheet.flatten(style) : style,
-  //   breakpoint
-  // )({ theme })
+  const nativeStyles = css(
+    Array.isArray(style)
+      ? StyleSheet.flatten(style)
+      : StyleSheet.flatten([style]),
+    breakpoint
+  )({ theme })
 
   const superStyle = css(sx, breakpoint)({ theme })
 
@@ -542,7 +536,7 @@ export function mapPropsToStyledComponent<P, T>(
     ...baseStyle,
     ...multipleVariantsStyle,
     ...variantStyle,
-    // ...nativeStyles,
+    ...nativeStyles,
     ...superStyle,
   })
 

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@theme-ui/css'
 import { ThemeProvider, SxProps, useThemeUI } from '@theme-ui/core'
 import { useEffect, useRef, useState } from 'react'
-import { Dimensions, Platform, StyleSheet, ScaledSize } from 'react-native'
+import { Dimensions, Platform, ScaledSize } from 'react-native'
 // import { useDimensions } from '@react-native-community/hooks'
 import { ThemedOptions, StyledProps } from './types'
 import { defaultBreakpoints } from './breakpoints'

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -46,6 +46,14 @@ const responsive = (
       next[key] = value
       continue
     }
+    // for single value arrays, just add it to the style
+    // example: flex: [1]
+    // we do this since we create more dom nodes otherwise
+    if (value.length === 1) {
+      // @ts-ignore
+      next[key] = value[0]
+      continue
+    }
 
     if (Platform.OS === 'web') {
       next.responsiveSSRStyles = next.responsiveSSRStyles || []
@@ -488,7 +496,7 @@ export function mapPropsToStyledComponent<P, T>(
     sx,
     theme,
     variant = defaultVariant,
-    style,
+    // style,
     variants,
   } = props
 
@@ -521,10 +529,10 @@ export function mapPropsToStyledComponent<P, T>(
       {}
     )
 
-  const nativeStyles = css(
-    Array.isArray(style) ? StyleSheet.flatten(style) : style,
-    breakpoint
-  )({ theme })
+  // const nativeStyles = css(
+  //   Array.isArray(style) ? StyleSheet.flatten(style) : style,
+  //   breakpoint
+  // )({ theme })
 
   const superStyle = css(sx, breakpoint)({ theme })
 
@@ -534,7 +542,7 @@ export function mapPropsToStyledComponent<P, T>(
     ...baseStyle,
     ...multipleVariantsStyle,
     ...variantStyle,
-    ...nativeStyles,
+    // ...nativeStyles,
     ...superStyle,
   })
 

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -47,6 +47,12 @@ const responsive = (
       continue
     }
 
+    if (key === 'transform') {
+      // @ts-ignore
+      next[key] = value
+      continue
+    }
+
     if (Platform.OS === 'web') {
       next.responsiveSSRStyles = next.responsiveSSRStyles || []
 
@@ -340,6 +346,11 @@ export const css = (
         // here we extract theme values for each item
         breakpointStyle => css(breakpointStyle)(theme)
       )
+      continue
+    }
+
+    if (key === 'transform') {
+      result[key] = val
       continue
     }
 

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -493,10 +493,11 @@ export function mapPropsToStyledComponent<P, T>(
   } = props
 
   // overrride the defaults with added ones; don't get rid of them altogether
-  const multipleVariants = [...defaultVariants]
+  let multipleVariants = [...defaultVariants]
   if (variants?.length) {
-    multipleVariants.push(...variants)
+    multipleVariants = [...variants]
   }
+  multipleVariants.filter(Boolean)
 
   const baseStyle = css(defaultStyle, breakpoint)({ theme })
 

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -497,7 +497,7 @@ export function mapPropsToStyledComponent<P, T>(
   if (variants?.length) {
     multipleVariants = [...variants]
   }
-  multipleVariants.filter(Boolean)
+  multipleVariants = multipleVariants.filter(Boolean)
 
   const baseStyle = css(defaultStyle, breakpoint)({ theme })
 

--- a/src/css/ssr-component.tsx
+++ b/src/css/ssr-component.tsx
@@ -3,14 +3,13 @@ import { jsx, SxProps } from 'theme-ui'
 import React, { ComponentProps, ComponentType, Fragment } from 'react'
 import { ResponsiveSSRStyles } from '.'
 import { SSRMediaQuery } from '../provider'
-import { StyledProps } from './types'
 
 type Props<T> = {
   Component: ComponentType<T>
   responsiveStyles: ResponsiveSSRStyles
   style: unknown
   containerStyles?: SxProps['sx']
-  nativeStyle?: StyledProps<T>['style']
+  // nativeStyle?: StyledProps<T>['style']
 }
 
 const SSR = React.forwardRef(function SSRComponent<T>(
@@ -19,7 +18,7 @@ const SSR = React.forwardRef(function SSRComponent<T>(
     Component,
     style,
     containerStyles = {},
-    nativeStyle,
+    // nativeStyle,
     ...props
   }: Props<T>,
   ref: T
@@ -81,7 +80,7 @@ const SSR = React.forwardRef(function SSRComponent<T>(
                     <Component
                       {...((props as unknown) as T)}
                       ref={ref}
-                      style={[nativeStyle, style, breakpointStyle]}
+                      style={[style, breakpointStyle]}
                     />
                   ) : null}
                 </div>

--- a/src/css/ssr-component.tsx
+++ b/src/css/ssr-component.tsx
@@ -3,12 +3,14 @@ import { jsx, SxProps } from 'theme-ui'
 import React, { ComponentProps, ComponentType, Fragment } from 'react'
 import { ResponsiveSSRStyles } from '.'
 import { SSRMediaQuery } from '../provider'
+import { StyledProps } from './types'
 
 type Props<T> = {
   Component: ComponentType<T>
   responsiveStyles: ResponsiveSSRStyles
   style: unknown
   containerStyles?: SxProps['sx']
+  nativeStyle?: StyledProps<T>['style']
 }
 
 const SSR = React.forwardRef(function SSRComponent<T>(
@@ -17,6 +19,7 @@ const SSR = React.forwardRef(function SSRComponent<T>(
     Component,
     style,
     containerStyles = {},
+    nativeStyle,
     ...props
   }: Props<T>,
   ref: T
@@ -78,7 +81,7 @@ const SSR = React.forwardRef(function SSRComponent<T>(
                     <Component
                       {...((props as unknown) as T)}
                       ref={ref}
-                      style={[style, breakpointStyle]}
+                      style={[nativeStyle, style, breakpointStyle]}
                     />
                   ) : null}
                 </div>

--- a/src/css/types.ts
+++ b/src/css/types.ts
@@ -9,6 +9,10 @@ export type ThemedOptions<T> = {
     | ((props: T) => Required<Required<SxProps>['sx']>)
   themeKey?: string
   defaultVariant?: string
+  /**
+   * List of multiple variants
+   */
+  defaultVariants?: string[]
 }
 
 export type StyledProps<P> = SxProps & {
@@ -26,4 +30,5 @@ export type StyledProps<P> = SxProps & {
    * This styles the `div` that wraps your responsive item. CSS values are fine here, and they can also be responsive.
    */
   webContainerSx?: SxProps['sx']
+  variants?: string[]
 }

--- a/src/css/types.ts
+++ b/src/css/types.ts
@@ -22,6 +22,7 @@ export type StyledProps<P> = SxProps & {
   /**
    * Optional style value to pass react native styles that aren't available in the `sx` prop, such as shadows.
    */
+  // TODO uhh fix this mess
   // @ts-ignore
   style?: P['style'] extends [] ? P['style'][0] : P['style']
   breakpoint?: number

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,3 +12,4 @@ export type { Theme } from 'theme-ui'
 export { styled } from './css/styled'
 
 export { useThemeUI as useDripsyTheme } from 'theme-ui'
+export { remToPixels } from './utils/rem-to-pts'


### PR DESCRIPTION
# What

Allow multiple variants as modifiers on components.

This closes #42.

# How

The API is as follows:

1. Write variants just like you normally would in your theme
```ts
// theme.ts
export default {
  text: { large: { fontSize: 5 }, underline: { textDecoration: 'underline' } }
}
```

2. Use `variants` in your components
```tsx
<Text 
  variants={['large', 'underline']}
/>
```

2.1 (or, set `defaultVariants`)

```ts
const LargeText = styled(Text, { defaultVariants: ['large', 'underline'] })()
```

For overlapping styles, the later items in the array take precedent.

# Test Plan

- [ ] Add to example apps
- [x] Publish to npm `yarn add dripsy@multiple-variants`
- [x] Try in real-world app
