### PR TITLE
fix broken theme-ui link in README which is returning 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🍷 Dripsy
 
-A **dead-simple**, **responsive** design system for Expo / React Native Web. Heavily inspired by React's [`theme-ui`](https://theme-ui.com/home).
+A **dead-simple**, **responsive** design system for Expo / React Native Web. Heavily inspired by React's [`theme-ui`](https://theme-ui.com/).
 
 **Style once, run anywhere.**
 


### PR DESCRIPTION
seems like their routing has changed -- not sure if original intention was to link to homepage or first page of documentation

this PR sets the link to `theme-ui` homepage