### PR TITLE
[Web] Add hover support

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,13 +389,13 @@ export default theme
 You can now apply this `variant` to any `Text` element:
 
 ```tsx
-<View variant="scalable" />
+<Text variant="scalable" />
 ```
 
 If you have multiple variants, just pass a `variants` array:
 
 ```tsx
-<View variants={['scalable', 'some-other-variant']} />
+<Text variants={['scalable', 'some-other-variant']} />
 ```
 
 ### Animating your hover styles

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ const theme = {
 export default theme
 ```
 
-#### Considerations
+### Hover support consideration
 
 One thing to keep in mind: hover styles do not support Dripsy's responsive array syntax at this time. Please refrain from passing array styles to `&:hover` or the `hovered` prop, unless it is a `transform`, which doesn't support responsive styles.
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ If you have multiple variants, just pass a `variants` array:
 <Text variants={['scalable', 'some-other-variant']} />
 ```
 
-### Animating your hover styles
+## Animating your hover styles
 
 You can use `react-native-web`'s transition support to add smooth transitions when users hover:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A **dead-simple**, **responsive** design system for Expo / React Native Web. Hea
 
 # Features
 
+- [(New in 1.5.x)](#hover-support) Hover support for web (`hovered` prop, and `&:hover` for variants.)
 - [(New in 1.4.x!)](#using-custom-fonts-new-%EF%B8%8F) Custom fonts, edited globally
 - Responsive styles
 - Universal (Android, iOS, Web, & more)
@@ -24,7 +25,7 @@ A **dead-simple**, **responsive** design system for Expo / React Native Web. Hea
 - Works with Vanilla React Native
 - Works with Next.js / server-side rendering
 - Full theme support
-- Custom theme variants
+- Custom theme variants (including multiple variants!)
 - TypeScript support (TypeScript theme support is in the works too)
 - Insanely simple API (themed, responsive designs in one line!)
 - Works with Animated/Reanimated values
@@ -341,6 +342,89 @@ const CustomView = createThemedComponent(View, {
   },
 })
 ```
+
+# Hover support 🖐
+
+As of `1.5.x`, Dripsy provides out-of-the-box support for hover events. See more [here](https://github.com/nandorojo/dripsy/pull/69).
+
+To add hover styles directly, use the `hovered` prop on any Dripsy component:
+
+```tsx
+<View hovered={{ backgroundColor: 'primary' }} />
+```
+
+You can also use the `&:hover` syntax inside of `sx`:
+
+```tsx
+<View
+  sx={{
+    backgroundColor: 'primary',
+    '&:hover': { backgroundColor: 'text', transform: [{ scale: 1.1 }] },
+  }}
+/>
+```
+
+The `&:hover` syntax might be more familiar if you're used to CSS in JS. It is identical to the `hovered` prop. It's up to you to choose which you prefer. If you'll be using `&:hover` in your theme a lot, maybe stick to that syntax for consistency.
+
+## Hover support in your theme
+
+If you want to add hover styles to your theme, you can freely use the `&:hover` key inside of your variants.
+
+```ts
+// theme.ts
+const theme = {
+  ...,
+  text: {
+    scalable: {
+      '&:hover': {
+        transform: [{ scale: 1.1 }]
+      }
+    }
+  }
+}
+
+export default theme
+```
+
+You can now apply this `variant` to any `Text` element:
+
+```tsx
+<View variant="scalable" />
+```
+
+If you have multiple variants, just pass a `variants` array:
+
+```tsx
+<View variants={['scalable', 'some-other-variant']} />
+```
+
+### Animating your hover styles
+
+You can use `react-native-web`'s transition support to add smooth transitions when users hover:
+
+```ts
+// theme.ts
+const theme = {
+  ...,
+  text: {
+    scalable: {
+      transform: [{ scale: 1 }],
+      // smoothly transition our scale when someone hovers
+      transitionProperty: 'transform',
+      transitionDuration: '250ms',
+      '&:hover': {
+        transform: [{ scale: 1.1 }]
+      }
+    }
+  }
+}
+
+export default theme
+```
+
+#### Considerations
+
+One thing to keep in mind: hover styles do not support Dripsy's responsive array syntax at this time. Please refrain from passing array styles to `&:hover` or the `hovered` prop, unless it is a `transform`, which doesn't support responsive styles.
 
 # Using Custom Fonts [New! 🏄‍♂️]
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A **dead-simple**, **responsive** design system for Expo / React Native Web. Hea
 
 # Features
 
-- [(New in 1.5.x)](#hover-support) Hover support for web (`hovered` prop, and `&:hover` for variants.)
+- [(New in 1.5.x)](#hover-support-) Hover support for web (`hovered` prop, and `&:hover` for variants.)
 - [(New in 1.4.x!)](#using-custom-fonts-new-%EF%B8%8F) Custom fonts, edited globally
 - Responsive styles
 - Universal (Android, iOS, Web, & more)

--- a/examples/example/App.tsx
+++ b/examples/example/App.tsx
@@ -54,6 +54,11 @@ const theme = {
       bg: 'black',
     },
   },
+  ['hovered-red']: {
+    '&:hover': {
+      bg: 'red',
+    },
+  },
 }
 
 const G = createThemedComponent(Text, {
@@ -89,7 +94,7 @@ const HoverableVariantSquare = () => {
 }
 
 const HoverableMultipleVariantsSquare = () => {
-  return <View variants={['hover-square']} />
+  return <View variants={['hover-square', 'hovered-red']} />
 }
 
 export default function App() {

--- a/examples/example/App.tsx
+++ b/examples/example/App.tsx
@@ -80,11 +80,30 @@ export default function App() {
       <Container>
         <View
           sx={{
-            backgroundColor: () => ['primary', 'white'],
-            height: [400, 800],
+            backgroundColor: ['primary', 'white'],
+            height: 700,
+            transitionProperty: 'background-color',
+            transitionDuration: '250ms',
+          }}
+          hovered={{
+            backgroundColor: 'pink',
           }}
         >
-          <H4 sx={{ color: 'text', mb: 2, mt: 0, fontSize: [5] }}>Test</H4>
+          <H4
+            sx={{
+              color: 'text',
+              mb: 2,
+              mt: 0,
+              fontSize: 5,
+              '&:hover': {
+                color: 'primary',
+              },
+              transitionProperty: 'color',
+              transitionDuration: '250ms',
+            }}
+          >
+            OK
+          </H4>
           {/* <Pressable>
             {({ pressed }) => (
               <DripText sx={{ cursor: 'pointer' }}>

--- a/examples/example/App.tsx
+++ b/examples/example/App.tsx
@@ -44,6 +44,16 @@ const theme = {
       elevation: 25,
     },
   },
+  ['hover-square']: {
+    height: 100,
+    width: 100,
+    bg: 'primary',
+    transitionProperty: 'background-color',
+    transitionDuration: '250ms',
+    '&:hover': {
+      bg: 'black',
+    },
+  },
 }
 
 const G = createThemedComponent(Text, {
@@ -72,6 +82,14 @@ const ResponsiveSquare = () => {
       <DripText sx={{ color: textColor }}>Hello</DripText>
     </View>
   )
+}
+
+const HoverableVariantSquare = () => {
+  return <View variant="hover-square" />
+}
+
+const HoverableMultipleVariantsSquare = () => {
+  return <View variants={['hover-square']} />
 }
 
 export default function App() {
@@ -117,6 +135,8 @@ export default function App() {
             <Text>Card</Text>
           </View>
           <ResponsiveSquare />
+          <HoverableVariantSquare />
+          <HoverableMultipleVariantsSquare />
         </View>
       </Container>
     </DripsyProvider>

--- a/examples/example/App.tsx
+++ b/examples/example/App.tsx
@@ -94,7 +94,28 @@ const HoverableVariantSquare = () => {
 }
 
 const HoverableMultipleVariantsSquare = () => {
-  return <View variants={['hover-square', 'hovered-red']} />
+  return (
+    <View
+      // try commenting out one of the variants, or the hovered prop
+      variants={['hover-square', 'hovered-red']}
+      // you can use the 'hovered' prop
+      hovered={{
+        bg: 'cyan',
+      }}
+      sx={{
+        transitionProperty: 'transform, background-color',
+        transitionDuration: '250ms',
+        // or you can use '&:hover' in 'sx'
+        '&:hover': {
+          transform: [
+            {
+              scale: 1.1,
+            },
+          ],
+        },
+      }}
+    />
+  )
 }
 
 export default function App() {

--- a/examples/example/webpack.config.js
+++ b/examples/example/webpack.config.js
@@ -1,45 +1,48 @@
 /* eslint-disable @typescript-eslint/camelcase */
 /* eslint-disable @typescript-eslint/no-var-requires */
-const path = require('path');
-const fs = require('fs');
-const createExpoWebpackConfigAsync = require('@expo/webpack-config');
-const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+const path = require('path')
+const fs = require('fs')
+const createExpoWebpackConfigAsync = require('@expo/webpack-config')
+const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin')
 
-const node_modules = path.resolve(__dirname, '../..', 'node_modules');
-const packages = path.resolve(__dirname, '../..', 'packages');
+const node_modules = path.resolve(__dirname, '../..', 'node_modules')
+const packages = path.resolve(__dirname, '../..', 'packages')
 
 module.exports = async function (env, argv) {
-  const config = await createExpoWebpackConfigAsync(env, argv);
+  const config = await createExpoWebpackConfigAsync(env, argv)
 
-  config.context = path.resolve(__dirname, '../..');
+  config.context = path.resolve(__dirname, '../..')
 
   config.module.rules.push({
     test: /\.(js|ts|tsx)$/,
     include: /(packages|example)\/.+/,
     exclude: /node_modules/,
     use: 'babel-loader',
-  });
+  })
 
   config.resolve.plugins = config.resolve.plugins.filter(
     (p) => !(p instanceof ModuleScopePlugin)
-  );
+  )
 
-  Object.assign(config.resolve.alias, {
-    'react': path.resolve(node_modules, 'react'),
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    react: path.resolve(node_modules, 'react'),
     'react-native': path.resolve(node_modules, 'react-native-web'),
     'react-native-web': path.resolve(node_modules, 'react-native-web'),
     '@expo/vector-icons': path.resolve(node_modules, '@expo/vector-icons'),
-  });
+  }
 
   fs.readdirSync(packages)
     .filter((name) => !name.startsWith('.'))
     .forEach((name) => {
-      config.resolve.alias[name === 'dripsy' ? 'dripsy' :`@dripsy/${name}`] = path.resolve(
+      config.resolve.alias[
+        name === 'dripsy' ? 'dripsy' : `@dripsy/${name}`
+      ] = path.resolve(
         packages,
         name,
         require(`../../packages/${name}/package.json`).source
-      );
-    });
+      )
+    })
 
-  return config;
-};
+  return config
+}

--- a/examples/next-example/package.json
+++ b/examples/next-example/package.json
@@ -3,15 +3,15 @@
   "version": "0.0.1",
   "main": "__generated__/AppEntry.js",
   "dependencies": {
-    "expo": "^40.0.0",
     "next": "9.4.4",
     "next-compose-plugins": "^2.2.0",
     "next-transpile-modules": "3.3.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-native": "0.63.4",
-    "react-native-unimodules": "~0.12.0",
-    "react-native-web": "~0.13.12"
+    "expo": "^40.0.0",
+    "react": "~16.9.0",
+    "react-dom": "~16.9.0",
+    "react-native": "~0.61.5",
+    "react-native-unimodules": "~0.9.0",
+    "react-native-web": "^0.14.10"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/packages/dripsy/package.json
+++ b/packages/dripsy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.4.17",
+  "version": "1.5.0-alpha.1",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/dripsy/package.json
+++ b/packages/dripsy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.5.0-alpha.1",
+  "version": "1.5.0-alpha.2",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/dripsy/package.json
+++ b/packages/dripsy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dripsy",
-  "version": "1.5.0-alpha.2",
+  "version": "1.5.0-alpha.3",
   "description": "🍷 A super-simple responsive design system for React Native Web.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/dripsy/src/css/create-themed-component.tsx
+++ b/packages/dripsy/src/css/create-themed-component.tsx
@@ -73,6 +73,7 @@ export function createThemedComponent<P, T>(
 
     if (Platform.OS === 'web' && !!responsiveSSRStyles?.length) {
       return (
+        // TODO make isHoverable = Object.keys(hoverStyles).length > 0
         <Hoverable isHoverable={false}>
           {({ isHovered }) => (
             <SSRComponent

--- a/packages/dripsy/src/css/create-themed-component.tsx
+++ b/packages/dripsy/src/css/create-themed-component.tsx
@@ -95,7 +95,6 @@ export function createThemedComponent<P, T>(
 
     if (Platform.OS === 'web' && !!responsiveSSRStyles?.length) {
       return (
-        // TODO make isHoverable = Object.keys(hoverStyles).length > 0
         <Hoverable isHoverable={isHoverable}>
           {({ isHovered }) => {
             return (

--- a/packages/dripsy/src/css/create-themed-component.tsx
+++ b/packages/dripsy/src/css/create-themed-component.tsx
@@ -5,6 +5,7 @@ import { useThemeUI } from '@theme-ui/core'
 import { useBreakpointIndex, mapPropsToStyledComponent } from '.'
 import { SSRComponent } from './ssr-component'
 import { Platform } from 'react-native'
+import Hoverable from '../pseudo-events/Hoverable'
 
 type Props<P> = Omit<StyledProps<P>, 'theme' | 'breakpoint'>
 
@@ -72,23 +73,35 @@ export function createThemedComponent<P, T>(
 
     if (Platform.OS === 'web' && !!responsiveSSRStyles?.length) {
       return (
-        <SSRComponent
-          {...props}
-          Component={TheComponent as React.ComponentType<unknown>}
-          responsiveStyles={responsiveSSRStyles}
-          style={styles}
-          ref={ref}
-          containerStyles={
-            webContainerSx as ComponentProps<
-              typeof SSRComponent
-            >['containerStyles']
-          }
-        />
+        <Hoverable isHoverable={false}>
+          {({ isHovered }) => (
+            <SSRComponent
+              {...props}
+              Component={TheComponent as React.ComponentType<unknown>}
+              responsiveStyles={responsiveSSRStyles}
+              style={styles}
+              ref={ref}
+              containerStyles={
+                webContainerSx as ComponentProps<
+                  typeof SSRComponent
+                >['containerStyles']
+              }
+            />
+          )}
+        </Hoverable>
       )
     }
 
     return (
-      <TheComponent {...((props as unknown) as P)} ref={ref} style={styles} />
+      <Hoverable isHoverable={false}>
+        {({ isHovered }) => (
+          <TheComponent
+            {...((props as unknown) as P)}
+            ref={ref}
+            style={styles}
+          />
+        )}
+      </Hoverable>
     )
   })
 

--- a/packages/dripsy/src/css/create-themed-component.tsx
+++ b/packages/dripsy/src/css/create-themed-component.tsx
@@ -98,12 +98,6 @@ export function createThemedComponent<P, T>(
         // TODO make isHoverable = Object.keys(hoverStyles).length > 0
         <Hoverable isHoverable={isHoverable}>
           {({ isHovered }) => {
-            if (isHoverable) {
-              console.log('[create-themed-component]', {
-                isHovered,
-                hoverStyles,
-              })
-            }
             return (
               <SSRComponent
                 {...props}
@@ -126,13 +120,15 @@ export function createThemedComponent<P, T>(
 
     return (
       <Hoverable isHoverable={isHoverable}>
-        {({ isHovered }) => (
-          <TheComponent
-            {...((props as unknown) as P)}
-            ref={ref}
-            style={[styles, isHovered && hoverStyles]}
-          />
-        )}
+        {({ isHovered }) => {
+          return (
+            <TheComponent
+              {...((props as unknown) as P)}
+              ref={ref}
+              style={[styles, isHovered && hoverStyles]}
+            />
+          )
+        }}
       </Hoverable>
     )
   })

--- a/packages/dripsy/src/css/create-themed-component.tsx
+++ b/packages/dripsy/src/css/create-themed-component.tsx
@@ -46,16 +46,14 @@ export function createThemedComponent<P, T>(
     const breakpoint = useBreakpointIndex({
       __shouldDisableListenerOnWeb: true,
     })
-    // const ssr = useIsSSR()
     // change/remove this later maybe
-    const ssr = Platform.OS === 'web'
 
     const { responsiveSSRStyles, ...styles } = useMemo(
       () =>
         mapPropsToStyledComponent<P, T>(
           {
             theme,
-            breakpoint: Platform.OS === 'web' && ssr ? undefined : breakpoint,
+            breakpoint: Platform.OS === 'web' ? undefined : breakpoint,
             variant,
             sx,
             style,
@@ -67,22 +65,12 @@ export function createThemedComponent<P, T>(
             defaultStyle,
           }
         )(),
-      [
-        breakpoint,
-        defaultStyle,
-        ssr,
-        style,
-        sx,
-        theme,
-        themeKey,
-        variant,
-        variants,
-      ]
+      [breakpoint, defaultStyle, style, sx, theme, themeKey, variant, variants]
     )
 
     const TheComponent = SuperComponent || Component
 
-    if (Platform.OS === 'web' && ssr && !!responsiveSSRStyles?.length) {
+    if (Platform.OS === 'web' && !!responsiveSSRStyles?.length) {
       return (
         <SSRComponent
           {...props}

--- a/packages/dripsy/src/css/index.tsx
+++ b/packages/dripsy/src/css/index.tsx
@@ -716,14 +716,6 @@ export function mapPropsToStyledComponent<P, T>(
     }
   }
 
-  addPseudoElementToStyle(sx, 'your sx prop', '&:hover')
-  addPseudoElementToStyle(
-    // polyfill the "hovered" prop, as if it were in a style object
-    { '&:hover': hoveredProp },
-    'your hovered prop',
-    '&:hover'
-  )
-
   // overrride the defaults with added ones; don't get rid of them altogether
   let multipleVariants = [...defaultVariants]
   if (variants?.length) {
@@ -781,6 +773,15 @@ export function mapPropsToStyledComponent<P, T>(
   // support both &:hover syntax as well as the hover prop.
 
   const superStyle = css(sx, breakpoint)({ theme, fontFamily })
+
+  // important to call this after the variants
+  addPseudoElementToStyle(sx, 'your sx prop', '&:hover')
+  addPseudoElementToStyle(
+    // polyfill the "hovered" prop, as if it were in a style object
+    { '&:hover': hoveredProp },
+    'your hovered prop',
+    '&:hover'
+  )
 
   // TODO optimize with StyleSheet.create()
   // TODO IMPORTANT deep merge the `responsiveSSRStyles` from each style above!

--- a/packages/dripsy/src/css/index.tsx
+++ b/packages/dripsy/src/css/index.tsx
@@ -741,11 +741,8 @@ export function mapPropsToStyledComponent<P, T>(
 
   const multipleVariantsStyle = multipleVariants
     .map((variantKey) => {
-      const resolvedVariant = get(
-        theme,
-        themeKey + '.' + variantKey,
-        get(theme, variantKey)
-      )
+      const resolvedVariant =
+        get(theme, themeKey + '.' + variantKey, get(theme, variantKey)) || {}
       addPseudoElementToStyle(
         // avoid mutating the theme
         { ...resolvedVariant },

--- a/packages/dripsy/src/css/index.tsx
+++ b/packages/dripsy/src/css/index.tsx
@@ -649,6 +649,7 @@ export function mapPropsToStyledComponent<P, T>(
     hovered: hoveredProp = {},
   } = props
 
+  // avoid unintentional mutations
   const sx = { ...sxProp } as typeof sxProp
 
   // initialize hover styles

--- a/packages/dripsy/src/css/index.tsx
+++ b/packages/dripsy/src/css/index.tsx
@@ -693,11 +693,11 @@ export function mapPropsToStyledComponent<P, T>(
 
     // get the styles corresponding to this event
     // omit responsiveSSRStyles for now
-    const { [event]: hoveredStyle } = styleProp
+    const { [event]: pseudoEventStyle } = styleProp
     const {
       responsiveSSRStyles: themedPseudoElementResponsiveStyle,
       ...themedPseudoElementStyle
-    } = css(hoveredStyle, breakpoint)({ theme, fontFamily })
+    } = css(pseudoEventStyle, breakpoint)({ theme, fontFamily })
 
     invariantResponsiveStyles(
       stylePropName,

--- a/packages/dripsy/src/css/index.tsx
+++ b/packages/dripsy/src/css/index.tsx
@@ -649,7 +649,7 @@ export function mapPropsToStyledComponent<P, T>(
     hovered: hoveredProp = {},
   } = props
 
-  const sx = { ...sxProp }
+  const sx = { ...sxProp } as typeof sxProp
 
   // initialize hover styles
   let finalHoverStyles: ThemeUIStyleObject = {}
@@ -772,8 +772,6 @@ export function mapPropsToStyledComponent<P, T>(
   // isolate out hover styles
   // support both &:hover syntax as well as the hover prop.
 
-  const superStyle = css(sx, breakpoint)({ theme, fontFamily })
-
   // important to call this after the variants
   addPseudoElementToStyle(sx, 'your sx prop', '&:hover')
   addPseudoElementToStyle(
@@ -782,6 +780,8 @@ export function mapPropsToStyledComponent<P, T>(
     'your hovered prop',
     '&:hover'
   )
+
+  const superStyle = css(sx, breakpoint)({ theme, fontFamily })
 
   // TODO optimize with StyleSheet.create()
   // TODO IMPORTANT deep merge the `responsiveSSRStyles` from each style above!

--- a/packages/dripsy/src/css/ssr-component.tsx
+++ b/packages/dripsy/src/css/ssr-component.tsx
@@ -8,6 +8,7 @@ type Props<T> = {
   Component: ComponentType<T>
   responsiveStyles: ResponsiveSSRStyles
   style: unknown
+  hoverStyles: unknown
   containerStyles?: SxProps['sx']
   // nativeStyle?: StyledProps<T>['style']
 }
@@ -18,6 +19,7 @@ const SSR = React.forwardRef(function SSRComponent<T>(
     Component,
     style,
     containerStyles = {},
+    hoverStyles,
     // nativeStyle,
     ...props
   }: Props<T>,
@@ -92,7 +94,7 @@ const SSR = React.forwardRef(function SSRComponent<T>(
                     <Component
                       {...((props as unknown) as T)}
                       ref={ref}
-                      style={[style, breakpointStyle]}
+                      style={[style, breakpointStyle, hoverStyles]}
                     />
                   ) : null}
                 </div>

--- a/packages/dripsy/src/css/types.ts
+++ b/packages/dripsy/src/css/types.ts
@@ -18,6 +18,7 @@ export type StyledProps<P> = {
   sx?: ThemeUIStyleObject & {
     '&:hover'?: ThemeUIStyleObject
   }
+  hovered?: ThemeUIStyleObject
   as?: ComponentType<P>
   variant?: string
   themeKey?: string

--- a/packages/dripsy/src/css/types.ts
+++ b/packages/dripsy/src/css/types.ts
@@ -14,10 +14,12 @@ export type ThemedOptions<T> = {
   defaultVariants?: string[]
 }
 
+export type StyleWithPseudoElements = ThemeUIStyleObject & {
+  '&:hover'?: ThemeUIStyleObject
+}
+
 export type StyledProps<P> = {
-  sx?: ThemeUIStyleObject & {
-    '&:hover'?: ThemeUIStyleObject
-  }
+  sx?: StyleWithPseudoElements
   hovered?: ThemeUIStyleObject
   as?: ComponentType<P>
   variant?: string

--- a/packages/dripsy/src/css/types.ts
+++ b/packages/dripsy/src/css/types.ts
@@ -1,12 +1,11 @@
 import type { SxProps } from '@theme-ui/core'
-import type { Theme } from '@theme-ui/css'
+import type { Theme, ThemeUIStyleObject } from '@theme-ui/css'
 import type { ComponentType } from 'react'
 // import { SxStyleProp } from 'theme-ui'
 
 export type ThemedOptions<T> = {
-  defaultStyle?:
-    | SxProps['sx']
-    | ((props: T) => Required<Required<SxProps>['sx']>)
+  defaultStyle?: ThemeUIStyleObject
+  // | ((props: T) => NonNullable<ThemeUIStyleObject>)
   themeKey?: string
   defaultVariant?: string
   /**
@@ -15,7 +14,10 @@ export type ThemedOptions<T> = {
   defaultVariants?: string[]
 }
 
-export type StyledProps<P> = SxProps & {
+export type StyledProps<P> = {
+  sx?: ThemeUIStyleObject & {
+    '&:hover'?: ThemeUIStyleObject
+  }
   as?: ComponentType<P>
   variant?: string
   themeKey?: string

--- a/packages/dripsy/src/pseudo-events/HoverState.ts
+++ b/packages/dripsy/src/pseudo-events/HoverState.ts
@@ -1,0 +1,43 @@
+import { Platform } from 'react-native'
+// https://gist.github.com/ianmartorell/32bb7df95e5eff0a5ee2b2f55095e6a6
+
+/* eslint-disable no-inner-declarations */
+
+let isEnabled = false
+
+const canUseDOM = Platform.OS === 'web' && typeof window !== 'undefined'
+
+if (canUseDOM) {
+  /**
+   * Web browsers emulate mouse events (and hover states) after touch events.
+   * This code infers when the currently-in-use modality supports hover
+   * (including for multi-modality devices) and considers "hover" to be enabled
+   * if a mouse movement occurs more than 1 second after the last touch event.
+   * This threshold is long enough to account for longer delays between the
+   * browser firing touch and mouse events on low-powered devices.
+   */
+  const HOVER_THRESHOLD_MS = 1000
+  let lastTouchTimestamp = 0
+
+  const enableHover = () => {
+    if (isEnabled || Date.now() - lastTouchTimestamp < HOVER_THRESHOLD_MS) {
+      return
+    }
+    isEnabled = true
+  }
+
+  const disableHover = () => {
+    lastTouchTimestamp = Date.now()
+    if (isEnabled) {
+      isEnabled = false
+    }
+  }
+
+  document.addEventListener('touchstart', disableHover, true)
+  document.addEventListener('touchmove', disableHover, true)
+  document.addEventListener('mousemove', enableHover, true)
+}
+
+export function isHoverEnabled(): boolean {
+  return isEnabled
+}

--- a/packages/dripsy/src/pseudo-events/Hoverable.tsx
+++ b/packages/dripsy/src/pseudo-events/Hoverable.tsx
@@ -62,7 +62,7 @@ HoverableProps) {
       ? children({ isHovered: isHoverable && showHover && isHovered })
       : children
 
-  if (!isHoverable || Platform.OS !== 'web') <>{child}</>
+  if (!isHoverable || Platform.OS !== 'web') return <>{child}</>
 
   return React.cloneElement(React.Children.only(child), {
     onMouseEnter: handleMouseEnter,

--- a/packages/dripsy/src/pseudo-events/Hoverable.tsx
+++ b/packages/dripsy/src/pseudo-events/Hoverable.tsx
@@ -1,0 +1,77 @@
+// https://gist.github.com/ianmartorell/32bb7df95e5eff0a5ee2b2f55095e6a6
+
+import React, { useCallback, ReactNode } from 'react'
+import { Platform } from 'react-native'
+
+import { isHoverEnabled } from './HoverState'
+
+export interface HoverableProps {
+  onHoverIn?: () => void
+  onHoverOut?: () => void
+  children: ((props: { isHovered: boolean }) => ReactNode) | ReactNode
+  /**
+   * Set this to `false` if there are no hover styles.
+   *
+   * This way, we avoid even setting up hover states.
+   */
+  isHoverable: boolean
+  /**
+   * If `isHoverable` is false, it will return this node instead.
+   *
+   * Maybe we should deprecate this. Not sure TBH.
+   *
+   * The only real reason to keep this is to avoid having a function component in render...
+   */
+  //   nonHoverableNode: React.ReactNode
+}
+
+export default function Hoverable({
+  onHoverIn,
+  onHoverOut,
+  children,
+  isHoverable,
+}: //   nonHoverableNode
+HoverableProps) {
+  const [isHovered, setHovered] = React.useState(false)
+  const [showHover, setShowHover] = React.useState(true)
+
+  const handleMouseEnter = useCallback(() => {
+    if (isHoverEnabled() && !isHovered) {
+      if (onHoverIn) onHoverIn()
+      setHovered(true)
+    }
+  }, [isHovered, onHoverIn])
+
+  const handleMouseLeave = useCallback(() => {
+    if (isHovered) {
+      if (onHoverOut) onHoverOut()
+      setHovered(false)
+    }
+  }, [isHovered, onHoverOut])
+
+  const handleGrant = useCallback(() => {
+    setShowHover(false)
+  }, [])
+
+  const handleRelease = useCallback(() => {
+    setShowHover(true)
+  }, [])
+
+  const child =
+    typeof children === 'function'
+      ? children({ isHovered: isHoverable && showHover && isHovered })
+      : children
+
+  if (!isHoverable || Platform.OS !== 'web') <>{child}</>
+
+  return React.cloneElement(React.Children.only(child), {
+    onMouseEnter: handleMouseEnter,
+    onMouseLeave: handleMouseLeave,
+    // prevent hover showing while responder
+    onResponderGrant: handleGrant,
+    onResponderRelease: handleRelease,
+    // if child is Touchable
+    onPressIn: handleGrant,
+    onPressOut: handleRelease,
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,7 +173,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.12.10", "@babel/generator@^7.12.11", "@babel/generator@^7.5.0", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
+"@babel/generator@^7.0.0", "@babel/generator@^7.12.10", "@babel/generator@^7.12.11", "@babel/generator@^7.7.7", "@babel/generator@^7.9.0":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
   integrity sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
@@ -3962,23 +3962,12 @@
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-debugger-ui@^4.13.1", "@react-native-community/cli-debugger-ui@^4.9.0":
+"@react-native-community/cli-debugger-ui@^4.9.0":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"
   integrity sha512-UFnkg5RTq3s2X15fSkrWY9+5BKOFjihNSnJjTV2H5PtTUFbd55qnxxPw8CxSfK0bXb1IrSvCESprk2LEpqr5cg==
   dependencies:
     serve-static "^1.13.1"
-
-"@react-native-community/cli-hermes@^4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-4.13.0.tgz#6243ed9c709dad5e523f1ccd7d21066b32f2899d"
-  integrity sha512-oG+w0Uby6rSGsUkJGLvMQctZ5eVRLLfhf84lLyz942OEDxFRa9U19YJxOe9FmgCKtotbYiM3P/XhK+SVCuerPQ==
-  dependencies:
-    "@react-native-community/cli-platform-android" "^4.13.0"
-    "@react-native-community/cli-tools" "^4.13.0"
-    chalk "^3.0.0"
-    hermes-profile-transformer "^0.0.6"
-    ip "^1.1.5"
 
 "@react-native-community/cli-platform-android@^3.0.0":
   version "3.1.4"
@@ -3993,7 +3982,7 @@
     slash "^3.0.0"
     xmldoc "^1.1.2"
 
-"@react-native-community/cli-platform-android@^4.10.0", "@react-native-community/cli-platform-android@^4.13.0":
+"@react-native-community/cli-platform-android@^4.10.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-4.13.0.tgz#922681ec82ee1aadd993598b814df1152118be02"
   integrity sha512-3i8sX8GklEytUZwPnojuoFbCjIRzMugCdzDIdZ9UNmi/OhD4/8mLGO0dgXfT4sMWjZwu3qjy45sFfk2zOAgHbA==
@@ -4046,21 +4035,6 @@
     serve-static "^1.13.1"
     ws "^1.1.0"
 
-"@react-native-community/cli-server-api@^4.13.1":
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-4.13.1.tgz#bee7ee9702afce848e9d6ca3dcd5669b99b125bd"
-  integrity sha512-vQzsFKD9CjHthA2ehTQX8c7uIzlI9A7ejaIow1I9RlEnLraPH2QqVDmzIdbdh5Od47UPbRzamCgAP8Bnqv3qwQ==
-  dependencies:
-    "@react-native-community/cli-debugger-ui" "^4.13.1"
-    "@react-native-community/cli-tools" "^4.13.0"
-    compression "^1.7.1"
-    connect "^3.6.5"
-    errorhandler "^1.5.0"
-    nocache "^2.1.0"
-    pretty-format "^25.1.0"
-    serve-static "^1.13.1"
-    ws "^1.1.0"
-
 "@react-native-community/cli-tools@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-3.0.0.tgz#fe48b80822ed7e49b8af051f9fe41e22a2a710b1"
@@ -4087,11 +4061,6 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-3.0.0.tgz#488d46605cb05e88537e030f38da236eeda74652"
   integrity sha512-ng6Tm537E/M42GjE4TRUxQyL8sRfClcL7bQWblOCoxPZzJ2J3bdALsjeG3vDnVCIfI/R0AeFalN9KjMt0+Z/Zg==
-
-"@react-native-community/cli-types@^4.10.1":
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-4.10.1.tgz#d68a2dcd1649d3b3774823c64e5e9ce55bfbe1c9"
-  integrity sha512-ael2f1onoPF3vF7YqHGWy7NnafzGu+yp88BbFbP0ydoCP2xGSUzmZVw0zakPTC040Id+JQ9WeFczujMkDy6jYQ==
 
 "@react-native-community/cli@^3.0.0":
   version "3.2.1"
@@ -4138,47 +4107,6 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
     ws "^1.1.0"
-
-"@react-native-community/cli@^4.10.0":
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-4.13.1.tgz#60148723e77cafe3ae260317d6bffe91853a2d20"
-  integrity sha512-+/TeRVToADpQPSprsPkwi9KY8x64YcuJpjzMBVISwWP+aWzsIDuWJmyMXTADlCg2EBMJqJR7bn1W/IkfzVRCWA==
-  dependencies:
-    "@hapi/joi" "^15.0.3"
-    "@react-native-community/cli-debugger-ui" "^4.13.1"
-    "@react-native-community/cli-hermes" "^4.13.0"
-    "@react-native-community/cli-server-api" "^4.13.1"
-    "@react-native-community/cli-tools" "^4.13.0"
-    "@react-native-community/cli-types" "^4.10.1"
-    chalk "^3.0.0"
-    command-exists "^1.2.8"
-    commander "^2.19.0"
-    cosmiconfig "^5.1.0"
-    deepmerge "^3.2.0"
-    envinfo "^7.7.2"
-    execa "^1.0.0"
-    find-up "^4.1.0"
-    fs-extra "^8.1.0"
-    glob "^7.1.3"
-    graceful-fs "^4.1.3"
-    inquirer "^3.0.6"
-    leven "^3.1.0"
-    lodash "^4.17.15"
-    metro "^0.58.0"
-    metro-config "^0.58.0"
-    metro-core "^0.58.0"
-    metro-react-native-babel-transformer "^0.58.0"
-    metro-resolver "^0.58.0"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    node-stream-zip "^1.9.1"
-    ora "^3.4.0"
-    pretty-format "^25.2.0"
-    semver "^6.3.0"
-    serve-static "^1.13.1"
-    strip-ansi "^5.2.0"
-    sudo-prompt "^9.0.0"
-    wcwidth "^1.0.1"
 
 "@react-native-community/eslint-config@^1.1.0":
   version "1.1.0"
@@ -5416,11 +5344,6 @@ anser@1.4.9:
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.9.tgz#1f85423a5dcf8da4631a341665ff675b96845760"
   integrity sha512-AI+BjTeGt2+WFk4eWcqbQ7snZpDBt8SaLlj0RT2h5xfdWaiy51OjYvqwMrNzJLGy8iOAL6nKDITWO+rd4MkYEA==
 
-anser@^1.4.9:
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
-  integrity sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==
-
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -5762,7 +5685,7 @@ art@^0.10.0:
   resolved "https://registry.yarnpkg.com/art/-/art-0.10.3.tgz#b01d84a968ccce6208df55a733838c96caeeaea2"
   integrity sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ==
 
-asap@^2.0.0, asap@~2.0.3, asap@~2.0.6:
+asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -9118,7 +9041,7 @@ envinfo@7.5.0:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.5.0.tgz#91410bb6db262fb4f1409bd506e9ff57e91023f4"
   integrity sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ==
 
-envinfo@^7.1.0, envinfo@^7.3.1, envinfo@^7.7.2:
+envinfo@^7.1.0, envinfo@^7.3.1:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.3.tgz#4b2d8622e3e7366afb8091b23ed95569ea0208cc"
   integrity sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==
@@ -9829,7 +9752,7 @@ expo-constants@~9.0.0:
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-9.0.0.tgz#35c600079ee91d38fe4f56375caae6e90f122fdd"
   integrity sha512-1kqZMM8Ez5JT3sTEx8I69fP6NYFLOJjeM6Z63dD/m2NiwvzSADiO5+BhghnWNGN1L3bxbgOjXS6EHtS7CdSfxA==
 
-expo-constants@~9.3.0, expo-constants@~9.3.3:
+expo-constants@~9.3.3:
   version "9.3.5"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-9.3.5.tgz#78085763e8ed100a5f2df7c682fd99631aa03d5e"
   integrity sha512-qIlv2ffSjQl3wrvJwXYoNfQNfH/sK46EXcgyEQnQ1SAQO4ukwTEpG9j3fdW6aTiVEVrv/DsA1IaVRqKrUwSd3A==
@@ -9871,11 +9794,6 @@ expo-image-loader@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-1.0.1.tgz#a83e336768df4dfcb8909aebb6d8152e256d7a72"
   integrity sha512-v7ziP+UGj+LArEmP//XTaqi9iFWRa8LAShNoFwwnpPS9huM8q3I+P16xK+GTo+4bQa1pPSIFBUZ8KqwAc+k8mQ==
-
-expo-image-loader@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-1.3.0.tgz#06982a1a02f443ba6afa2cc7a4f0ccebc26a5415"
-  integrity sha512-kn+9hm42TtHi1wFEp/1nq63vp33/cIbypI2hYjGsL22PAC9yk1go1hs/ktKgVWVlgmi0ruwR09SrM6ndOs7s7w==
 
 expo-keep-awake@~8.4.0:
   version "8.4.0"
@@ -11413,18 +11331,6 @@ hermes-engine@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
   integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
-
-hermes-engine@~0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.5.1.tgz#601115e4b1e0a17d9aa91243b96277de4e926e09"
-  integrity sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg==
-
-hermes-profile-transformer@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz#bd0f5ecceda80dd0ddaae443469ab26fb38fc27b"
-  integrity sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==
-  dependencies:
-    source-map "^0.7.3"
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -14311,38 +14217,6 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metro-babel-register@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.58.0.tgz#5c44786d49a044048df56cf476a2263491d4f53a"
-  integrity sha512-P5+G3ufhSYL6cA3a7xkbSJzzFBvtivj/PhWvGXFXnuFssDlMAX1CTktff+0gpka5Cd6B6QLt0UAMWulUAAE4Eg==
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-async-to-generator" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/register" "^7.0.0"
-    core-js "^2.2.2"
-    escape-string-regexp "^1.0.5"
-
-metro-babel-register@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.59.0.tgz#2bcff65641b36794cf083ba732fbc46cf870fb43"
-  integrity sha512-JtWc29erdsXO/V3loenXKw+aHUXgj7lt0QPaZKPpctLLy8kcEpI/8pfXXgVK9weXICCpCnYtYncIosAyzh0xjg==
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/register" "^7.0.0"
-    escape-string-regexp "^1.0.5"
-
 metro-babel-register@^0.56.0, metro-babel-register@^0.56.4:
   version "0.56.4"
   resolved "https://registry.yarnpkg.com/metro-babel-register/-/metro-babel-register-0.56.4.tgz#b0c627a1cfdd1bdd768f81af79481754e833a902"
@@ -14369,14 +14243,6 @@ metro-babel-transformer@0.58.0:
     "@babel/core" "^7.0.0"
     metro-source-map "0.58.0"
 
-metro-babel-transformer@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.59.0.tgz#dda99c75d831b00142c42c020c51c103b29f199d"
-  integrity sha512-fdZJl8rs54GVFXokxRdD7ZrQ1TJjxWzOi/xSP25VR3E8tbm3nBZqS+/ylu643qSr/IueABR+jrlqAyACwGEf6w==
-  dependencies:
-    "@babel/core" "^7.0.0"
-    metro-source-map "0.59.0"
-
 metro-babel-transformer@^0.56.4:
   version "0.56.4"
   resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.56.4.tgz#fe1d0dc600fcf90201a5bea4d42caea10b801057"
@@ -14384,16 +14250,6 @@ metro-babel-transformer@^0.56.4:
   dependencies:
     "@babel/core" "^7.0.0"
     metro-source-map "^0.56.4"
-
-metro-cache@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.58.0.tgz#630ea0a4626dfb9591c71fdb85dce14b5e9a04ec"
-  integrity sha512-jjW9zCTKxhgKcVkyQ6LHyna9Zdf4TK/45vvT1fPyyTk1RY82ZYjU1qs+84ycKEd08Ka4YcK9xcUew9SIDJYI8Q==
-  dependencies:
-    jest-serializer "^24.4.0"
-    metro-core "0.58.0"
-    mkdirp "^0.5.1"
-    rimraf "^2.5.4"
 
 metro-cache@^0.56.4:
   version "0.56.4"
@@ -14404,18 +14260,6 @@ metro-cache@^0.56.4:
     metro-core "^0.56.4"
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
-
-metro-config@0.58.0, metro-config@^0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.58.0.tgz#1e24b43a5a00971d75662b1a0d3c04a13d4a1746"
-  integrity sha512-4vgBliXwL56vjUlYplvGMVSNrJJpkHuLcD+O20trV3FvPxKg4ZsvuOcNSxqDSMU26FCtIEJ15ojcuCbRL7KY0w==
-  dependencies:
-    cosmiconfig "^5.0.5"
-    jest-validate "^24.7.0"
-    metro "0.58.0"
-    metro-cache "0.58.0"
-    metro-core "0.58.0"
-    pretty-format "^24.7.0"
 
 metro-config@^0.56.0, metro-config@^0.56.4:
   version "0.56.4"
@@ -14429,16 +14273,6 @@ metro-config@^0.56.0, metro-config@^0.56.4:
     metro-core "^0.56.4"
     pretty-format "^24.7.0"
 
-metro-core@0.58.0, metro-core@^0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.58.0.tgz#ad9f6645a2b439a3fbce7ce4e19b01b00375768a"
-  integrity sha512-RzXUjGFmCLOyzUqcKDvr91AldGtIOxnzNZrWUIiG8uC3kerVLo0mQp4YH3+XVm6fMNiLMg6iER7HLqD+MbpUjQ==
-  dependencies:
-    jest-haste-map "^24.7.1"
-    lodash.throttle "^4.1.1"
-    metro-resolver "0.58.0"
-    wordwrap "^1.0.0"
-
 metro-core@^0.56.0, metro-core@^0.56.4:
   version "0.56.4"
   resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.56.4.tgz#67cc41b3c0bf66e9c2306f50239a1080b1e82312"
@@ -14448,17 +14282,6 @@ metro-core@^0.56.0, metro-core@^0.56.4:
     lodash.throttle "^4.1.1"
     metro-resolver "^0.56.4"
     wordwrap "^1.0.0"
-
-metro-inspector-proxy@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.58.0.tgz#6fefb0cdf25655919d56c82ebe09cd26eb00e636"
-  integrity sha512-oFqTyNTJdCdvcw1Ha6SKE7ITbSaoTbO4xpYownIoJR+WZ0ZfxbWpp225JkHuBJm9UcBAnG9c0CME924m3uBbaw==
-  dependencies:
-    connect "^3.6.5"
-    debug "^2.2.0"
-    rxjs "^5.4.3"
-    ws "^1.1.5"
-    yargs "^14.2.0"
 
 metro-inspector-proxy@^0.56.4:
   version "0.56.4"
@@ -14470,13 +14293,6 @@ metro-inspector-proxy@^0.56.4:
     rxjs "^5.4.3"
     ws "^1.1.5"
     yargs "^9.0.0"
-
-metro-minify-uglify@0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.58.0.tgz#7e1066954bfd4f767ba6aca7feef676ca44c68b8"
-  integrity sha512-vRHsA7bCi7eCn3LXLm20EfY2NoWDyYOnmWaq/N8LB0OxL2L5DXRqMYAQK+prWGJ5S1yvVnDuuNVP+peQ9851TA==
-  dependencies:
-    uglify-es "^3.1.9"
 
 metro-minify-uglify@^0.56.4:
   version "0.56.4"
@@ -14514,50 +14330,6 @@ metro-react-native-babel-preset@0.58.0:
     "@babel/plugin-transform-parameters" "^7.0.0"
     "@babel/plugin-transform-react-display-name" "^7.0.0"
     "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-    "@babel/plugin-transform-regenerator" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-sticky-regex" "^7.0.0"
-    "@babel/plugin-transform-template-literals" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.5.0"
-    "@babel/plugin-transform-unicode-regex" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    react-refresh "^0.4.0"
-
-metro-react-native-babel-preset@0.59.0, metro-react-native-babel-preset@~0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.59.0.tgz#20e020bc6ac9849e1477de1333d303ed42aba225"
-  integrity sha512-BoO6ncPfceIDReIH8pQ5tQptcGo5yRWQXJGVXfANbiKLq4tfgdZB1C1e2rMUJ6iypmeJU9dzl+EhPmIFKtgREg==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-export-default-from" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
-    "@babel/plugin-syntax-export-default-from" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.2.0"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.0.0"
-    "@babel/plugin-transform-exponentiation-operator" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-for-of" "^7.0.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-object-assign" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
     "@babel/plugin-transform-regenerator" "^7.0.0"
     "@babel/plugin-transform-runtime" "^7.0.0"
@@ -14656,16 +14428,49 @@ metro-react-native-babel-preset@^0.61.0:
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.59.0:
+metro-react-native-babel-preset@~0.59.0:
   version "0.59.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.59.0.tgz#9b3dfd6ad35c6ef37fc4ce4d20a2eb67fabbb4be"
-  integrity sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.59.0.tgz#20e020bc6ac9849e1477de1333d303ed42aba225"
+  integrity sha512-BoO6ncPfceIDReIH8pQ5tQptcGo5yRWQXJGVXfANbiKLq4tfgdZB1C1e2rMUJ6iypmeJU9dzl+EhPmIFKtgREg==
   dependencies:
-    "@babel/core" "^7.0.0"
-    babel-preset-fbjs "^3.3.0"
-    metro-babel-transformer "0.59.0"
-    metro-react-native-babel-preset "0.59.0"
-    metro-source-map "0.59.0"
+    "@babel/plugin-proposal-class-properties" "^7.0.0"
+    "@babel/plugin-proposal-export-default-from" "^7.0.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.0.0"
+    "@babel/plugin-syntax-export-default-from" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.2.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
+    "@babel/plugin-transform-arrow-functions" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.0.0"
+    "@babel/plugin-transform-classes" "^7.0.0"
+    "@babel/plugin-transform-computed-properties" "^7.0.0"
+    "@babel/plugin-transform-destructuring" "^7.0.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+    "@babel/plugin-transform-for-of" "^7.0.0"
+    "@babel/plugin-transform-function-name" "^7.0.0"
+    "@babel/plugin-transform-literals" "^7.0.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
+    "@babel/plugin-transform-object-assign" "^7.0.0"
+    "@babel/plugin-transform-parameters" "^7.0.0"
+    "@babel/plugin-transform-react-display-name" "^7.0.0"
+    "@babel/plugin-transform-react-jsx" "^7.0.0"
+    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
+    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+    "@babel/plugin-transform-regenerator" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
+    "@babel/plugin-transform-spread" "^7.0.0"
+    "@babel/plugin-transform-sticky-regex" "^7.0.0"
+    "@babel/plugin-transform-template-literals" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.5.0"
+    "@babel/plugin-transform-unicode-regex" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    react-refresh "^0.4.0"
 
 metro-react-native-babel-transformer@^0.56.0:
   version "0.56.4"
@@ -14689,13 +14494,6 @@ metro-react-native-babel-transformer@^0.58.0:
     metro-react-native-babel-preset "0.58.0"
     metro-source-map "0.58.0"
 
-metro-resolver@0.58.0, metro-resolver@^0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.58.0.tgz#4d03edc52e2e25d45f16688adf3b3f268ea60df9"
-  integrity sha512-XFbAKvCHN2iWqKeiRARzEXn69eTDdJVJC7lu16S4dPQJ+Dy82dZBr5Es12iN+NmbJuFgrAuIHbpWrdnA9tOf6Q==
-  dependencies:
-    absolute-path "^0.0.0"
-
 metro-resolver@^0.56.4:
   version "0.56.4"
   resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.56.4.tgz#9876f57bca37fd1bfcffd733541e2ee4a89fad7f"
@@ -14713,19 +14511,6 @@ metro-source-map@0.58.0:
     invariant "^2.2.4"
     metro-symbolicate "0.58.0"
     ob1 "0.58.0"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
-
-metro-source-map@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.59.0.tgz#e9beb9fc51bfb4e060f95820cf1508fc122d23f7"
-  integrity sha512-0w5CmCM+ybSqXIjqU4RiK40t4bvANL6lafabQ2GP2XD3vSwkLY+StWzCtsb4mPuyi9R/SgoLBel+ZOXHXAH0eQ==
-  dependencies:
-    "@babel/traverse" "^7.0.0"
-    "@babel/types" "^7.0.0"
-    invariant "^2.2.4"
-    metro-symbolicate "0.59.0"
-    ob1 "0.59.0"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
@@ -14753,17 +14538,6 @@ metro-symbolicate@0.58.0:
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-symbolicate@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.59.0.tgz#fc7f93957a42b02c2bfc57ed1e8f393f5f636a54"
-  integrity sha512-asLaF2A7rndrToGFIknL13aiohwPJ95RKHf0NM3hP/nipiLDoMzXT6ZnQvBqDxkUKyP+51AI75DMtb+Wcyw4Bw==
-  dependencies:
-    invariant "^2.2.4"
-    metro-source-map "0.59.0"
-    source-map "^0.5.6"
-    through2 "^2.0.1"
-    vlq "^1.0.0"
-
 metro-symbolicate@^0.56.4:
   version "0.56.4"
   resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.56.4.tgz#53e9d40beac9049fa75a3e620ddd47d4907ff015"
@@ -14774,68 +14548,6 @@ metro-symbolicate@^0.56.4:
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
-
-metro@0.58.0, metro@^0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.58.0.tgz#c037318c112f80dc96199780c8b401ab72cfd142"
-  integrity sha512-yi/REXX+/s4r7RjzXht+E+qE6nzvFIrEXO5Q61h+70Q7RODMU8EnlpXx04JYk7DevHuMhFaX+NWhCtRINzR4zA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/core" "^7.0.0"
-    "@babel/generator" "^7.5.0"
-    "@babel/parser" "^7.0.0"
-    "@babel/plugin-external-helpers" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@babel/types" "^7.0.0"
-    absolute-path "^0.0.0"
-    async "^2.4.0"
-    babel-preset-fbjs "^3.3.0"
-    buffer-crc32 "^0.2.13"
-    chalk "^2.4.1"
-    ci-info "^2.0.0"
-    concat-stream "^1.6.0"
-    connect "^3.6.5"
-    debug "^2.2.0"
-    denodeify "^1.2.1"
-    eventemitter3 "^3.0.0"
-    fbjs "^1.0.0"
-    fs-extra "^1.0.0"
-    graceful-fs "^4.1.3"
-    image-size "^0.6.0"
-    invariant "^2.2.4"
-    jest-haste-map "^24.7.1"
-    jest-worker "^24.6.0"
-    json-stable-stringify "^1.0.1"
-    lodash.throttle "^4.1.1"
-    merge-stream "^1.0.1"
-    metro-babel-register "0.58.0"
-    metro-babel-transformer "0.58.0"
-    metro-cache "0.58.0"
-    metro-config "0.58.0"
-    metro-core "0.58.0"
-    metro-inspector-proxy "0.58.0"
-    metro-minify-uglify "0.58.0"
-    metro-react-native-babel-preset "0.58.0"
-    metro-resolver "0.58.0"
-    metro-source-map "0.58.0"
-    metro-symbolicate "0.58.0"
-    mime-types "2.1.11"
-    mkdirp "^0.5.1"
-    node-fetch "^2.2.0"
-    nullthrows "^1.1.1"
-    resolve "^1.5.0"
-    rimraf "^2.5.4"
-    serialize-error "^2.1.0"
-    source-map "^0.5.6"
-    strip-ansi "^4.0.0"
-    temp "0.8.3"
-    throat "^4.1.0"
-    wordwrap "^1.0.0"
-    write-file-atomic "^1.2.0"
-    ws "^1.1.5"
-    xpipe "^1.0.5"
-    yargs "^14.2.0"
 
 metro@^0.56.0, metro@^0.56.4:
   version "0.56.4"
@@ -15490,11 +15202,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-nocache@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
-  integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
-
 node-fetch-npm@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz#6507d0e17a9ec0be3bec516958a497cec54bf5a4"
@@ -15638,11 +15345,6 @@ node-releases@^1.1.25, node-releases@^1.1.52, node-releases@^1.1.53, node-releas
   version "1.1.67"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
   integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
-
-node-stream-zip@^1.9.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.12.0.tgz#f69af78799531b928662f4900d345387fa0b3777"
-  integrity sha512-HZ3XehqShTFj9gHauRJ3Bri9eiCTOII7/crtXzURtT14NdnOFs9Ia5E82W7z3izVBNx760tqwddxrBJVG52Y1Q==
 
 noop-fn@^1.0.0:
   version "1.0.0"
@@ -15894,7 +15596,7 @@ nth-check@^1.0.2, nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-nullthrows@^1.1.0, nullthrows@^1.1.1:
+nullthrows@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
@@ -15918,11 +15620,6 @@ ob1@0.58.0:
   version "0.58.0"
   resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.58.0.tgz#484a1e9a63a8b79d9ea6f3a83b2a42110faac973"
   integrity sha512-uZP44cbowAfHafP1k4skpWItk5iHCoRevMfrnUvYCfyNNPPJd3rfDCyj0exklWi2gDXvjlj2ObsfiqP/bs/J7Q==
-
-ob1@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.59.0.tgz#ee103619ef5cb697f2866e3577da6f0ecd565a36"
-  integrity sha512-opXMTxyWJ9m68ZglCxwo0OPRESIC/iGmKFPXEXzMZqsVIrgoRXOHmoMDkQzz4y3irVjbyPJRAh5pI9fd0MJTFQ==
 
 ob1@^0.56.4:
   version "0.56.4"
@@ -17352,7 +17049,7 @@ pretty-format@^24.7.0, pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^25.1.0, pretty-format@^25.2.0, pretty-format@^25.2.1, pretty-format@^25.5.0:
+pretty-format@^25.1.0, pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
@@ -17440,13 +17137,6 @@ promise@^7.1.1:
   integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
   dependencies:
     asap "~2.0.3"
-
-promise@^8.0.3:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
-  integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
-  dependencies:
-    asap "~2.0.6"
 
 prompts@^2.0.1, prompts@^2.3.2:
   version "2.4.0"
@@ -17783,24 +17473,6 @@ react-devtools-core@^3.6.3:
     shell-quote "^1.6.1"
     ws "^3.3.1"
 
-react-devtools-core@^4.6.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.10.1.tgz#6d57db291aeac9cc45ef9fb4636dd2ab97490daf"
-  integrity sha512-sXbBjGAWcf9HAblTP/zMtFhGHqxAfIR+GPxONZsSGN9FHnF4635dx1s2LdQWG9rJ+Ehr3nWg+BUAB6P78my5PA==
-  dependencies:
-    shell-quote "^1.6.1"
-    ws "^7"
-
-react-dom@16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
 react-dom@~16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
@@ -17835,31 +17507,6 @@ react-native-safe-area-context@3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz#48864ea976b0fa57142a2cc523e1fd3314e7247e"
   integrity sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==
-
-react-native-unimodules@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-unimodules/-/react-native-unimodules-0.12.0.tgz#f1c92eae92212ca44078c0991c78fa4d13fda0f8"
-  integrity sha512-/c1d3hr+3C3yIwhSoX+KTzy0+C9cnjUvenXP2uV8X2V3ZflnPB/HQXwZPHHWITmD89HP2n3NcPBTu4UgOv/KzQ==
-  dependencies:
-    "@unimodules/core" "~6.0.0"
-    "@unimodules/react-native-adapter" "~5.7.0"
-    chalk "^2.4.2"
-    expo-asset "~8.2.1"
-    expo-constants "~9.3.0"
-    expo-file-system "~9.3.0"
-    expo-image-loader "~1.3.0"
-    expo-permissions "~10.0.0"
-    unimodules-app-loader "~1.4.0"
-    unimodules-barcode-scanner-interface "~5.4.0"
-    unimodules-camera-interface "~5.4.0"
-    unimodules-constants-interface "~5.4.0"
-    unimodules-face-detector-interface "~5.4.0"
-    unimodules-file-system-interface "~5.4.0"
-    unimodules-font-interface "~5.4.0"
-    unimodules-image-loader-interface "~5.4.0"
-    unimodules-permissions-interface "~5.4.0"
-    unimodules-sensors-interface "~5.4.0"
-    unimodules-task-manager-interface "~5.4.0"
 
 react-native-unimodules@~0.9.0:
   version "0.9.1"
@@ -17900,54 +17547,6 @@ react-native-web@^0.14.10:
     normalize-css-color "^1.0.2"
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
-
-react-native-web@~0.13.12:
-  version "0.13.18"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.13.18.tgz#964f058a16521a3b9a31b091415edfef5b6ef305"
-  integrity sha512-WR/0ECAmwLQ2+2cL2Ur+0/swXFAtcSM0URoADJmG6D4MnY+wGc91JO8LoOTlgY0USBOY+qG/beRrjFa+RAuOiA==
-  dependencies:
-    array-find-index "^1.0.2"
-    create-react-class "^15.6.2"
-    deep-assign "^3.0.0"
-    fbjs "^1.0.0"
-    hyphenate-style-name "^1.0.3"
-    inline-style-prefixer "^5.1.0"
-    normalize-css-color "^1.0.2"
-    prop-types "^15.6.0"
-    react-timer-mixin "^0.13.4"
-
-react-native@0.63.4:
-  version "0.63.4"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.63.4.tgz#2210fdd404c94a5fa6b423c6de86f8e48810ec36"
-  integrity sha512-I4kM8kYO2mWEYUFITMcpRulcy4/jd+j9T6PbIzR0FuMcz/xwd+JwHoLPa1HmCesvR1RDOw9o4D+OFLwuXXfmGw==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    "@react-native-community/cli" "^4.10.0"
-    "@react-native-community/cli-platform-android" "^4.10.0"
-    "@react-native-community/cli-platform-ios" "^4.10.0"
-    abort-controller "^3.0.0"
-    anser "^1.4.9"
-    base64-js "^1.1.2"
-    event-target-shim "^5.0.1"
-    fbjs "^1.0.0"
-    fbjs-scripts "^1.1.0"
-    hermes-engine "~0.5.0"
-    invariant "^2.2.4"
-    jsc-android "^245459.0.0"
-    metro-babel-register "0.59.0"
-    metro-react-native-babel-transformer "0.59.0"
-    metro-source-map "0.59.0"
-    nullthrows "^1.1.1"
-    pretty-format "^24.9.0"
-    promise "^8.0.3"
-    prop-types "^15.7.2"
-    react-devtools-core "^4.6.0"
-    react-refresh "^0.4.0"
-    regenerator-runtime "^0.13.2"
-    scheduler "0.19.1"
-    stacktrace-parser "^0.1.3"
-    use-subscription "^1.0.0"
-    whatwg-fetch "^3.0.0"
 
 react-native@~0.61.5:
   version "0.61.5"
@@ -17998,15 +17597,6 @@ react-timer-mixin@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
   integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
-
-react@16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 react@~16.9.0:
   version "16.9.0"
@@ -18828,14 +18418,6 @@ scheduler@0.15.0, scheduler@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
   integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@0.19.1, scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -21026,13 +20608,6 @@ use-subscription@1.4.1:
   dependencies:
     object-assign "^4.1.1"
 
-use-subscription@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
-  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
-  dependencies:
-    object-assign "^4.1.1"
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -21871,7 +21446,7 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7, ws@^7.2.3:
+ws@^7.2.3:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.1.tgz#a333be02696bd0e54cea0434e21dcc8a9ac294bb"
   integrity sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==
@@ -22106,7 +21681,7 @@ yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^14.2.0, yargs@^14.2.2:
+yargs@^14.2.2:
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
   integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==


### PR DESCRIPTION
In addition to the `Pressable` component, it would be nice to style components directly with hover styles.

Components should:

1. Intelligently listen for hover events, if and only if there is a non-empty set of hover styles.
2. Only capture hover events on web.
3. Use theme values in hover styles.

# API

There are two options I see here:

```tsx
<View sx={{ '&:hover': { bg: 'blue' }, bg: 'green' }} />
```

Or

```tsx
<View hovered={{ bg: 'blue' }} sx={{ bg: 'green' }} />
```

I think the second one perhaps looks prettier...but the first one might be more scalable. This would ideally let us have hover styles in our theme's variants, etc.

```ts
// theme.ts
export default {
  buttons: {
    primary: {
      '&:hover': {
        bg: 'blue'
      },
      bg: 'green'
    }
  }
}
```

I have to think about which syntax I prefer. Second seems more satisfying to use. 🤔

## TODO

- [x] Capture hover events
- [x] Add SSR support
- [x] Add example and test
- [x] Inject actual hover styles logic into `mapPropsToStyledComponent`/`css` functions. This should probably be handled similar to `responsiveSSRStyles`. Ideally we can think of a method of doing this that would also support other pseudo elements, such as focus, in the future.
- [x] Publish to `pseudo` tag on NPM.
- [x] Document
- [x] Add support with `sx` prop.

All the boilerplate stateful hover logic is complete. All that's left is to construct the `hoverStyles` to pass when `isHovered` is `true`.

## Notes

I am leaning towards not supporting responsive arrays for hover styles at first. It's just going to get really messy with the current implementation. Maybe once it all works, we can add support for this again.
