### PR TITLE
Configure JSX runtime per file 

### DIFF
--- a/packages/core/src/css/ssr-component.tsx
+++ b/packages/core/src/css/ssr-component.tsx
@@ -1,4 +1,4 @@
-/** @jsx jsx */
+/** @jsxRuntime classic */
 import { jsx, SxProps } from '@theme-ui/core'
 import { ThemeUIStyleObject } from '@theme-ui/css'
 import React, { ComponentProps, ComponentType, Fragment } from 'react'

--- a/packages/core/src/css/ssr-component.tsx
+++ b/packages/core/src/css/ssr-component.tsx
@@ -1,4 +1,5 @@
 /** @jsxRuntime classic */
+/** @jsx jsx */
 import { jsx, SxProps } from '@theme-ui/core'
 import { ThemeUIStyleObject } from '@theme-ui/css'
 import React, { ComponentProps, ComponentType, Fragment } from 'react'


### PR DESCRIPTION
This fixes #96 by configuring the JSX runtime per file. By doing this, we can use the classic runtime but still use the new JSX runtime alongside it (e.g: CRA).