### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ export default {
   fontSizes: [16, 20, 24, 32],
   text: {
     h1: {
-      fontSize: 3, // this is 24px, taken from `fontSize` above
+      fontSize: 2, // this is 24px, taken from `fontSize` above
     },
     p: {
-      fontSize: 1, // & this is 16px, taken from `fontSize` above
+      fontSize: 0, // & this is 16px, taken from `fontSize` above
     },
   },
 }
@@ -237,7 +237,7 @@ export default {
 <Text
   sx={{
     color: 'primary',
-    padding: [1, 3], // [4px, 16px] from theme!
+    padding: [1, 3], // [4px, 16px] from theme.space
   }}
 >
   Themed color!
@@ -250,8 +250,8 @@ export default {
 import { H1, H2, P } from 'dripsy'
 ;<H1
   sx={{
-    color: 'text', // #000 from theme!
-    fontSize: 2, // 24px from theme!
+    color: 'text', // #000 from theme.colors
+    fontSize: 2, // 24px from theme.fontSizes
   }}
 ></H1>
 ```
@@ -637,7 +637,7 @@ import { useFonts } from 'expo-font'
 
 export default function Fonts({ children }: { children: React.ReactNode }) {
   const [loaded] = useFonts({
-    // 🚨🚨🚨 the name (`sans`) of the default weight here should equal the key from theme.customFonts!
+    // 🚨🚨🚨 the name (`sans`) of the default weight here should equal the key from theme.customFonts
     // otherwise, you will need to explicitly set the fontWeight everywhere
     // since we have theme.customFonts.sans, we name this `sans`
     ['sans']: require('./public/fonts/sansBook.ttf'),


### PR DESCRIPTION
Typo indicated 1-indexing but 0-indexing is correct.
Also removed some exclamation marks which could potentially be confused with bangs (Esp. if coming from Ruby).