### PR TITLE
fix: Broken Getting Started Next/Expo Doc Links

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -16,5 +16,5 @@ npm i dripsy
 
 If you're using Web, please see the following docs:
 
-- [Next.js](/getting-started/web/next) (This includes Expo + Next.js)
-- [Expo Web](/getting-started/web/expo)
+- [Next.js](/get-started/web/next) (This includes Expo + Next.js)
+- [Expo Web](/get-started/web/expo)

--- a/docs/pages/get-started/setup.mdx
+++ b/docs/pages/get-started/setup.mdx
@@ -38,4 +38,4 @@ export default function App({ Component, pageProps }) {
 }
 ```
 
-Be sure to refer to the [Dripsy Next.js](/getting-started/web/next) docs for full setup.
+Be sure to refer to the [Dripsy Next.js](/get-started/web/next) docs for full setup.

--- a/docs/pages/get-started/web/expo.mdx
+++ b/docs/pages/get-started/web/expo.mdx
@@ -1,6 +1,6 @@
 # Expo Web
 
-> If you're using Next.js, use the [Next.js docs](/getting-started/web/next) instead.
+> If you're using Next.js, use the [Next.js docs](/get-started/web/next) instead.
 
 If you're using `expo start:web`, this section is for you.
 


### PR DESCRIPTION
Fixes some broken links for the getting started documentation for Next and Expo. Wasn't sure if this qualifies for `docs` or `fix` commit prefixing, but I went with the latter.