### PR TITLE
More type improvements

### DIFF
--- a/examples/example/App.tsx
+++ b/examples/example/App.tsx
@@ -9,6 +9,7 @@ import {
   makeTheme,
   TextInput as DripsyInput,
   useResponsiveValue,
+  ActivityIndicator,
 } from 'dripsy'
 // Import from core
 import { H4 } from '@dripsy/core'
@@ -43,6 +44,7 @@ const theme = makeTheme({
     onlyAllowThemeValues: {
       // let's only restrict colors!
       // colors: 'always',
+      space: 'always',
     },
     // strictVariants: true,
   },
@@ -127,8 +129,10 @@ const ResponsiveSquare = () => {
       sx={{
         bg: 'cool',
         padding: ['$3'],
+        height: (theme) => theme.space.$1,
+        pb: (theme) => [theme.space.$3, '$5'],
       }}
-      variant=""
+      variant="layout.narrow"
     >
       <View ref={ref} />
       <DripsyInput ref={input} />
@@ -139,6 +143,7 @@ const ResponsiveSquare = () => {
       >
         Hello
       </DripText>
+      <ActivityIndicator color="gray" />
     </View>
   )
 }

--- a/packages/core/src/components/activity-indicator.tsx
+++ b/packages/core/src/components/activity-indicator.tsx
@@ -1,21 +1,29 @@
 import React, { ComponentProps } from 'react'
 import { ActivityIndicator as NativeActivityIndicator } from 'react-native'
 import { useDripsyTheme } from '../use-dripsy-theme'
-import { createThemedComponent } from '../css/create-themed-component'
 import { DripsyFinalTheme } from '../declarations'
+import { useSx } from '../use-sx'
+import { SxProp } from '../css/types'
 
 type Props = Omit<ComponentProps<typeof NativeActivityIndicator>, 'color'> & {
   color?: (string & {}) | keyof DripsyFinalTheme['colors']
 }
 
-function Indicator(props: Props) {
+function Indicator(props: Props & { sx?: SxProp }) {
   const { colors } = useDripsyTheme().theme
+  const sx = useSx()
 
   let { color } = props
   if (typeof color === 'string' && colors?.[color]) {
     color = colors[color] as string
   }
-  return <NativeActivityIndicator {...props} color={color} />
+  return (
+    <NativeActivityIndicator
+      {...props}
+      color={color as string}
+      style={[props.style, props.sx && sx(props.sx)]}
+    />
+  )
 }
 
-export const ActivityIndicator = createThemedComponent(Indicator)
+export const ActivityIndicator = Indicator


### PR DESCRIPTION
- Adds `ActivityIndicator` autocomplete for the `color` prop
- Fixes #165 
- Addresses #164 by allowing custom values when used in a factory function
  - `<View sx={{ p: () => 10 }} />`

Published to `3.7.0-alpha.1`'s canary

```sh
yarn add dripsy@canary
```