### PR TITLE
Added the export for DripsyTextInputProps type

### DIFF
--- a/packages/core/src/declarations.ts
+++ b/packages/core/src/declarations.ts
@@ -2,6 +2,8 @@ import type { ViewStyle, TextStyle, ImageStyle } from 'react-native'
 import type { Theme } from '@theme-ui/css'
 import type { Function } from 'ts-toolbelt'
 
+export { DripsyTextInputProps } from './components/TextInput'
+
 export type Shadows = Pick<
   ViewStyle,
   | 'elevation'
@@ -201,10 +203,10 @@ export interface DripsyBaseTheme
      *
      */
     onlyAllowThemeValues?:
-      | OnlyAllowThemeValues
-      | {
-          [key in keyof Omit<DripsyBaseTheme, 'types'>]?: OnlyAllowThemeValues
-        }
+    | OnlyAllowThemeValues
+    | {
+      [key in keyof Omit<DripsyBaseTheme, 'types'>]?: OnlyAllowThemeValues
+    }
     /**
      * @deprecated See the `strictVariants` option instead
      * Defaults to `undefined | string & {}`. Set it to `undefined` to enforce that your variants match your theme.
@@ -246,11 +248,11 @@ export function makeTheme<T extends DripsyBaseTheme>(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface DripsyCustomTheme {}
+export interface DripsyCustomTheme { }
 
 export interface DripsyFinalTheme
   extends Omit<DripsyBaseTheme, keyof DripsyCustomTheme>,
-    DripsyCustomTheme {}
+  DripsyCustomTheme { }
 
 export type DripsyThemeWithoutIgnoredKeys<Theme = DripsyCustomTheme> = Omit<
   Theme,


### PR DESCRIPTION
## Problem
I was creating the TextArea component, which acts like the ``<textarea>`` HTML element. The problem I was facing was that DripsyTextInputProps (which Dripsy's TextInput is using) wasn't exported, which prevented me to type the props for my custom component.

To visualize this issue:
```js
import { TextInputProps } from 'react-native'
import { TextInput } from 'dripsy'
import { styles } from "./TextArea.css"

// The props have the invalid types
export const TextArea = (props: TextInputProps) => {
  return (
    <TextInput
      {...props}
      multiline
      numberOfLines={10}
      sx={styles.textArea}
    />
  )
}
```
The TypeScript error:
```
Type '{ multiline: true; numberOfLines: number; sx: { width: number; height: number; textAlignVertical: string; borderWidth: number; }; allowFontScaling?: boolean | undefined; autoCapitalize?: "none" | "sentences" | "words" | "characters" | undefined; ... 106 more ...; showSoftInputOnFocus?: boolean | undefined; }' is not assignable to type '{ selectionColor?: (string & {}) | undefined; placeholderTextColor?: (string & {}) | undefined; underlineColorAndroid?: (string & {}) | undefined; }'.
  Types of property 'selectionColor' are incompatible.
    Type 'ColorValue | undefined' is not assignable to type '(string & {}) | undefined'.
      Type 'OpaqueColorValue' is not assignable to type '(string & {}) | undefined'.
        Type 'OpaqueColorValue' is not assignable to type 'string & {}'.
          Type 'OpaqueColorValue' is not assignable to type 'string'.ts(2322)
```

## Solution
It seems it isn't exported anywhere, so I had to manually add export for the DripsyTextInputProps, which allowed me to type the props correctly.

```js
import { TextInput, DripsyTextInputProps } from 'dripsy'
import { styles } from "./TextArea.css"

// No TypeScript errors anymore
export const TextArea = (props: DripsyTextInputProps ) => {
  return (
    <TextInput
      {...props}
      multiline
      numberOfLines={10}
      sx={styles.textArea}
    />
  )
}
```