### PR TITLE
Fix: borderBottomEndRadius not defined in scales and aliases

### DIFF
--- a/packages/core/src/css/scales.ts
+++ b/packages/core/src/css/scales.ts
@@ -60,6 +60,7 @@ export const aliases = {
 
   bbc: 'borderBottomColor',
   bblr: 'borderBottomLeftRadius',
+  bber: 'borderBottomEndRadius',
   bbrr: 'borderBottomRightRadius',
   bbw: 'borderBottomWidth',
   blc: 'borderLeftColor',
@@ -171,6 +172,7 @@ export const scales = {
   borderTopLeftRadius: 'radii',
   borderBottomRightRadius: 'radii',
   borderBottomLeftRadius: 'radii',
+  borderBottomEndRadius: 'radii',
   borderTopWidth: 'borderWidths',
   borderTopColor: 'colors',
   borderTopStyle: 'borderStyles',


### PR DESCRIPTION
- Added `borderBottomEndRadius` in aliases and scales to fix following exception in react native

`JSON value of type NSString cannot be converted to NSNumber`

<img src="https://user-images.githubusercontent.com/43571677/224472647-984fb949-d631-42b5-88d0-9e15ce703a08.png"  width="400"/>
