### PR TITLE
fix: Remove `const` from types-v2 declarations.ts

### DIFF
--- a/packages/dripsy/src/core/types-v2/declarations.ts
+++ b/packages/dripsy/src/core/types-v2/declarations.ts
@@ -245,7 +245,7 @@ export interface DripsyBaseTheme
   }
 }
 
-export function makeTheme<const T extends DripsyBaseTheme>(
+export function makeTheme<T extends DripsyBaseTheme>(
   theme: Function.Narrow<T>
 ): Function.Narrow<T> {
   return theme


### PR DESCRIPTION
The `const` was breaking the types in our Solito-app.

I might be wrong, but it looks like the `const` was a typo.