### PR TITLE
Fix placeholderTextColor color not able to use theme colors

### DIFF
--- a/packages/dripsy/src/core/components/TextInput.tsx
+++ b/packages/dripsy/src/core/components/TextInput.tsx
@@ -34,7 +34,7 @@ export const TextInput = forwardRef<rTextInput, DripsyTextInputProps>(
   function TextInput({ ...props }, ref) {
     const { theme } = useDripsyTheme()
     Object.keys(colorKeys).forEach((key) => {
-      if (props[key] && theme?.colors && key in theme.colors) {
+      if (props[key] && theme?.colors && props[key] in theme.colors) {
         props[key] = theme.colors[props[key]]
       }
     })


### PR DESCRIPTION
Fix the following TextInput's props unable to map color in theme :

- selectionColor
- underlineColorAndroid
- placeholderTextColor

 