### PR TITLE
fix(styled): add default type for Extra to fix Intellisense in JS

### DIFF
--- a/packages/dripsy/src/core/css/styled.tsx
+++ b/packages/dripsy/src/core/css/styled.tsx
@@ -31,7 +31,7 @@ export function styled<
     defaultVariant?: (string & {}) | MaybeVariantsFromThemeKey<ThemeKey>
   } = {}
 ) {
-  function dripsyFactory<Extra>(
+  function dripsyFactory<Extra = {}>(
     defaultStyle?: ThemedOptions<Extra, ThemeKey>['defaultStyle']
   ) {
     return createThemedComponent<C, Extra, ThemeKey>(Component, {


### PR DESCRIPTION
When I use the `styled` function in a JavaScript file instead of a TypeScript file as shown below, Intellisense breaks in VSCode because the Extra type gets evaluated to `undefined`. Adding this default type fixes that and shouldn't have any negative impact on TypeScript users as far as I can tell.

```js
styled(MyComponent)({
    fontSize: 12
});
```

| Before | After |
| -- | -- |
| ![image](https://github.com/nandorojo/dripsy/assets/1267900/d6980715-83f8-4407-be45-08bde3789338) | ![image](https://github.com/nandorojo/dripsy/assets/1267900/c3bb57dd-b955-4a87-88e2-8d5f2d042470) |
