### PR TITLE
📱 🖥️  Add "Responsive Design" page to docs

### DIFF
--- a/docs/pages/usage/meta.json
+++ b/docs/pages/usage/meta.json
@@ -1,0 +1,4 @@
+{
+  "overview": "Overview",
+  "responsive-design": "Responsive Design"
+}

--- a/docs/pages/usage/responsive-design.mdx
+++ b/docs/pages/usage/responsive-design.mdx
@@ -1,0 +1,60 @@
+# Responsive Design
+
+Dripsy provides in-line support for setting responsive values. You just have to provide an array values for style properties, and dripsy will automatically match the values to the breakpoints:
+
+```jsx
+<Text
+  sx={{
+    fontSize: [14, 16, 20], // 14 on mobile, 16 on tablet, 20 on desktop
+    color: ['$primary', null, 'accent'], // `primary` on mobile & tablet, `accent` on desktop
+  }}
+>
+  Responsive font size?? 🤯
+</Text>
+```
+
+## Default breakpoints
+
+Dripsy provides [Bootstrap's](https://getbootstrap.com/docs/5.0/layout/breakpoints/) default breakpoints:
+
+- **576** (landscape phones, 576px and up)
+- **768** (tablets, 768px and up)
+- **992** (desktops, 992px and up)
+- **1200** (large desktops, 1200px and up)
+
+In the previous example, fontSize 14 would be applied for <576px, 16 for <768px, and 20 for anything at or above 992px.
+
+## Overriding default breakpoints
+
+You can pass in your own breakpoints into [makeTheme](/apis/makeTheme):
+
+```ts
+const theme = makeTheme({
+  breakpoints: ['576', '768', '992', '1200'],
+  // ...
+})
+```
+
+## Retrieving breakpoint values outside themes
+
+Dripsy provides two hooks for working with breakpoints:
+
+### `useBreakpoints()`
+
+Returns the current array of breakpoints:
+
+```ts
+const breakpoints = useBreakpoints()
+console.log(breakpoints) // [576, 768, 992, 1200]
+```
+
+### `useBreakpointIndex()`
+
+Returns the index of the current breakpoint. For example, if we have the default breakpoints, and the screen's width is 1600px, the hook will return `4`.
+
+```ts
+const breakpointIndex = useBreakpointIndex()
+console.log(breakpointIndex) // 4
+```
+
+You can also use this hook to conditionally render components based on screen size. For example, to only render a certain component if the user is viewing the screen on a desktop, you can use `{breakpointIndex >= 4 && (...)}`

--- a/docs/pages/usage/responsive-design.mdx
+++ b/docs/pages/usage/responsive-design.mdx
@@ -1,6 +1,6 @@
 # Responsive Design
 
-Dripsy provides in-line support for setting responsive values. You just have to provide an array values for style properties, and dripsy will automatically match the values to the breakpoints:
+Dripsy provides in-line support for setting responsive values in your styles. You just have to provide an array values in your styles, and dripsy will automatically match the values to the breakpoints:
 
 ```jsx
 <Text
@@ -22,11 +22,9 @@ Dripsy provides [Bootstrap's](https://getbootstrap.com/docs/5.0/layout/breakpoin
 - **992** (desktops, 992px and up)
 - **1200** (large desktops, 1200px and up)
 
-In the previous example, fontSize 14 would be applied for <576px, 16 for <768px, and 20 for anything at or above 992px.
-
 ## Overriding default breakpoints
 
-You can pass in your own breakpoints into [makeTheme](/apis/makeTheme):
+You can also pass in your own breakpoints into [makeTheme](/apis/makeTheme):
 
 ```ts
 const theme = makeTheme({
@@ -50,11 +48,17 @@ console.log(breakpoints) // [576, 768, 992, 1200]
 
 ### `useBreakpointIndex()`
 
-Returns the index of the current breakpoint. For example, if we have the default breakpoints, and the screen's width is 1600px, the hook will return `4`.
+Returns the index of the current breakpoint. For example, if your theme has the default breakpoints, and the screen's width is 1600px, the hook returns `4`.
 
 ```ts
 const breakpointIndex = useBreakpointIndex()
 console.log(breakpointIndex) // 4
 ```
 
-You can also use this hook to conditionally render components based on screen size. For example, to only render a certain component if the user is viewing the screen on a desktop, you can use `{breakpointIndex >= 4 && (...)}`
+- width <576 ➡️ 0
+- width 576-767 ➡️ 1
+- width 768-991 ➡️ 2
+- width 992-1119 ➡️ 3
+- and width >=1200 ➡️ 4
+
+You can also use this hook to conditionally render components based on screen size. For example, to only render a certain component if the user is viewing the page on a desktop, you can use `{breakpointIndex >= 4 && (...)}`


### PR DESCRIPTION
I thought it'd be nice to document the `useBreakpoints()` and `useBreakpointIndex()` hooks so that their presence is more apparent, and that their usage is more straightforward. This can also help convince people that dripsy isn't only for mobile projects. So I wrote up some docs on how to use them.

Unfortunately I wasn't able to run the docs page locally to test if it actually renders correctly 😅 So before it gets merged I'd need some help with running that. 🙏  (Maybe a nice candidate for the contributing guidelines?)

yarn build output:
```
danielgergely@Daniels-MacBook-Pro-2 docs % yarn build
yarn run v1.22.19
$ next build
info  - Using webpack 5. Reason: Enabled by default https://nextjs.org/docs/messages/webpack5
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
info  - Checking validity of types
warn  - The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config

Failed to compile.

./pages/_app.js
Error: Parsing error: DeprecationError: 'originalKeywordKind' has been deprecated since v5.0.0 and can no longer be used. Use 'identifierToKeywordKind(identifier)' instead.

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

yarn dev output:
```
danielgergely@Daniels-MacBook-Pro-2 docs % yarn dev
yarn run v1.22.19
$ next
ready - started server on 0.0.0.0:3000, url: http://localhost:3000
info  - Using webpack 5. Reason: Enabled by default https://nextjs.org/docs/messages/webpack5
info  - automatically enabled Fast Refresh for 1 custom loader
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:138971:18)
    at BulkUpdateDecorator.update (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:138872:50)
    at OriginalSource.updateHash (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack-sources3/index.js:1:10264)
    at NormalModule._initBuildHash (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68468:17)
    at handleParseResult (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68534:10)
    at /Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68628:4
    at processResult (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68343:11)
    at /Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68407:5
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:138971:18)
    at BulkUpdateDecorator.update (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:138872:50)
    at OriginalSource.updateHash (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack-sources3/index.js:1:10264)
    at NormalModule._initBuildHash (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68468:17)
    at handleParseResult (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68534:10)
    at /Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68628:4
    at processResult (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68343:11)
    at /Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68407:5
node:internal/crypto/hash:69
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:138971:18)
    at BulkUpdateDecorator.update (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:138872:50)
    at OriginalSource.updateHash (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack-sources3/index.js:1:10264)
    at NormalModule._initBuildHash (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68468:17)
    at handleParseResult (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68534:10)
    at /Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68628:4
    at processResult (/Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68343:11)
    at /Users/danielgergely/github/dripsy/docs/node_modules/next/dist/compiled/webpack/bundle5.js:68407:5 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.18.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```